### PR TITLE
Remove sudo from commands

### DIFF
--- a/installcmd/commands.yaml
+++ b/installcmd/commands.yaml
@@ -1,12 +1,12 @@
 linux:
   debian:
-    install: "sudo apt-get install"
-    update: "sudo apt-get update"
+    install: "apt-get install"
+    update: "apt-get update"
 
   arch:
-    install: "sudo pacman -S"
-    update: "sudo pacman -Sy"
+    install: "pacman -S"
+    update: "pacman -Sy"
 
   manjaro:
-    install: "sudo pacman -S"
-    update: "sudo pacman -Sy"
+    install: "pacman -S"
+    update: "pacman -Sy"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="installcmd",
-    version="0.2.1",
+    version="0.2.2",
     author="Azat Akhmetov",
     description="Print correct command for installing a package.",
     long_description=Path("README.md").read_text(),


### PR DESCRIPTION
It makes more sense to let the user decide whether to sudo, and we can't assume that `sudo` will always be installed either.
